### PR TITLE
drivers: sensor: add ams as6221 temperature sensor driver support

### DIFF
--- a/drivers/sensor/ti/tmp108/Kconfig
+++ b/drivers/sensor/ti/tmp108/Kconfig
@@ -2,17 +2,19 @@
 
 # Copyright (c) 2021 Jimmy Johnson <catch22@fastmail.net>
 # Copyright (c) 2022 T-Mobile USA, Inc.
+# Copyright (c) 2025 Byteflies NV
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig TMP108
 	bool "TMP108 Temperature Sensor"
 	default y
-	depends on DT_HAS_TI_TMP108_ENABLED || DT_HAS_AMS_AS6212_ENABLED
+	depends on DT_HAS_TI_TMP108_ENABLED || DT_HAS_AMS_AS6212_ENABLED \
+			|| DT_HAS_AMS_AS6221_ENABLED
 	select I2C
 
 	help
-	  Enable driver for the TMP108 temperature sensor and/or it's variant
-	  the AMS AS621.
+	  Enable driver for the TMP108 temperature sensor and/or it's variants,
+	  the AMS AS621x, AS6221.
 
 if TMP108
 

--- a/drivers/sensor/ti/tmp108/tmp108.c
+++ b/drivers/sensor/ti/tmp108/tmp108.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2021 Jimmy Johnson <catch22@fastmail.net>
  * Copyright (c) 2022 T-Mobile USA, Inc.
+ * Copyright (c) 2025 Byteflies NV
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -438,3 +439,8 @@ DT_INST_FOREACH_STATUS_OKAY(TMP108_INIT)
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT ams_as6212
 DT_INST_FOREACH_STATUS_OKAY(AS6212_INIT)
+
+#define AS6221_INIT(n) TMP108_DEFINE(n, AMS_AS6221)
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT ams_as6221
+DT_INST_FOREACH_STATUS_OKAY(AS6221_INIT)

--- a/drivers/sensor/ti/tmp108/tmp108.h
+++ b/drivers/sensor/ti/tmp108/tmp108.h
@@ -32,6 +32,8 @@
 	 .TEMP_DIV = 2,                                                                            \
 	 IF_ENABLED(CONFIG_TMP108_ALERT_INTERRUPTS, (.CONF_POL = 0x0400))}
 
+#define AMS_AS6221_CONF AMS_AS6212_CONF
+
 #define TI_TMP108_CONF                                                                             \
 	{.CONF_M0 = 0x0100,                                                                        \
 	 .CONF_M1 = 0x0200,                                                                        \

--- a/dts/bindings/sensor/ams,as6221.yaml
+++ b/dts/bindings/sensor/ams,as6221.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2025 Byteflies NV
+# Copyright (c) 2022 T-Mobile USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    AMS AS6221 Digital Temperature Sensor.  See more info at
+    https://ams.com/en/as6221
+
+compatible: "ams,as6221"
+
+include: [sensor-device.yaml, i2c-device.yaml]
+
+properties:
+  alert-gpios:
+    type: phandle-array
+    description: |
+      Identifies the ALERT signal, which is active-low open drain when
+      produced by the sensor.

--- a/samples/sensor/tmp108/README.rst
+++ b/samples/sensor/tmp108/README.rst
@@ -14,7 +14,8 @@ also using low power one shot mode.
 Requirements
 ************
 
-A board with the :dtcompatible:`ti,tmp108` built in to its :ref:`devicetree <dt-guide>`,
+A board with either the :dtcompatible:`ti,tmp108` or :dtcompatible:`ams,as6212` or
+:dtcompatible:`ams,as6221` built in to its :ref:`devicetree <dt-guide>`,
 or a devicetree overlay with such a node added.
 
 Sample Output

--- a/samples/sensor/tmp108/sample.yaml
+++ b/samples/sensor/tmp108/sample.yaml
@@ -7,7 +7,9 @@ tests:
     depends_on:
       - i2c
       - gpio
-    filter: dt_compat_enabled("ti,tmp108")
+    filter: dt_compat_enabled("ti,tmp108") or
+            dt_compat_enabled("ams,as6212") or
+            dt_compat_enabled("ams,as6221")
     harness_config:
       type: multi_line
       regex:

--- a/samples/sensor/tmp108/src/main.c
+++ b/samples/sensor/tmp108/src/main.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 Jimmy Johnson <catch22@fastmail.net>
+ * Copyright (c) 2025 Byteflies NV
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -141,6 +142,10 @@ int main(void)
 		printf("warning: tmp108 device not found checking for compatible ams device\n");
 
 		temp_sensor = DEVICE_DT_GET_ANY(ams_as6212);
+	}
+
+	if (!temp_sensor) {
+		temp_sensor = DEVICE_DT_GET_ANY(ams_as6221);
 
 		if (!temp_sensor) {
 			printf("error: tmp108 compatible devices not found\n");

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -1218,6 +1218,11 @@ test_i2c_as6212: as6212@a3 {
 	reg = <0xa3>;
 };
 
+test_i2c_as6221: as6221@48 {
+	compatible = "ams,as6221";
+	reg = <0x48>;
+};
+
 test_i2c_p3t1755: p3t1755@a4 {
 	compatible = "nxp,p3t1755";
 	reg = <0xa4>;


### PR DESCRIPTION
The as6221 is functionally equivalent to ti tmp108 and ams as6212, so it is added as a new variant of tmp108.

Cherry-picked from https://github.com/zephyrproject-rtos/zephyr/pull/94899